### PR TITLE
Update index page with headings and links

### DIFF
--- a/fixity.rst
+++ b/fixity.rst
@@ -31,7 +31,9 @@ contents. An example can be seen in the error shown above:
       *Oxum error. Found 8 files and 71101 bytes on disk; expected 8 files and
       71100 bytes.*
 
-Fixity Application
+.. _fixity-application:
+
+Fixity application
 ------------------
 
 `Fixity`_ is also an application for use with the Archivematica Storage

--- a/index.rst
+++ b/index.rst
@@ -9,13 +9,74 @@
 Archivematica Storage Service documentation
 ===========================================
 
-This documentation describes the Storage Service, used by Archivematica to manage
-archival storage and transfer locations and packages.
+The Storage Service is used alongside Archivematica to manage the storage
+locations and packages for one or many Archivematica dashboards.
+
+For information about Archivematica, including user and administrator manuals,
+please see the :ref:`Archivematica documentation <archivematica:home>`.
+
+.. _storage-service-administration:
+
+Administering the Storage Service
+---------------------------------
+
+This section provides information for Storage Service administrators. This
+manual is intended for systems administrators who are responsible for
+installing, configuring, setting up, and maintaining Archivematica and related
+systems.
 
 * :ref:`Administering the Storage Service <administrators>`
-* :ref:`AIP recovery <recovery>`
-* :ref:`Installation <install>`
-* :ref:`Fixity application <fixity-docs>`
+* :ref:`Storage Service glossary and organization <organization>`
+* :ref:`Archivematica configuration <archivematica-configuration>`
+* :ref:`Pipelines <pipelines>`
+* :ref:`Spaces <spaces>`
+* :ref:`Locations <locations>`
+* :ref:`Packages <packages-tab>`
+* :ref:`Administration <administration>`
 
-Go to the :ref:`Archivematica User and Administrator <archivematica:home>`
-documentation.
+.. _storage-service-aip-recovery:
+
+AIP recovery
+------------
+
+AIP recovery support allows a storage service administrator to replace a corrupt
+version of a stored AIP with a correct version (restored from a backup, for
+example).
+
+* :ref:`AIP recovery <recovery>`
+* :ref:`How AIP recovery works <how-recovery-works>`
+* :ref:`Example recovery command <example-recovery-command>`
+* :ref:`Reporting recovery progress to external systems <reporting-recovery-progress>`
+
+.. _storage-service-fixity:
+
+Fixity
+------
+
+The Archivematica Storage Service exposes an `API endpoint`_ that allows users
+to check fixity on individual AIPs. `Fixity`_ is also an application for use
+with the Archivematica Storage Service. The Fixity application is run from the
+command-line and uses the API endpoint to perform batch checking across the
+entirety of the AIP storage location.
+
+* :ref:`Fixity <fixity-docs>`
+* :ref:`Fixity application <fixity-application>`
+
+.. _storage-service-installation:
+
+Installation
+------------
+
+This section describes how to install the Storage Service manually.
+
+.. note::
+   Most users install the Storage Service alongside Archivematica from Ansible
+   or packages using the :ref:`Archivematica general installation
+   <archivematica:installation>` documentation.
+
+* :ref:`Manually installing the Storage Service <install>`
+
+:ref:`Back to the top <index>`
+
+.. _`API endpoint`: https://wiki.archivematica.org/Storage_Service_API#Check_fixity
+.. _`Fixity`: https://github.com/artefactual/fixity

--- a/install.rst
+++ b/install.rst
@@ -5,9 +5,9 @@
     Holly Becker
     Misty De Meo
 
-=======
-Install
-=======
+=======================================
+Manually installing the Storage Service
+=======================================
 
 This page describes how to install the Storage Service manually; however for most users it is easier and better to install from Ansible or packages.
 Please the :ref:`Archivematica general installation <archivematica:installation>` documentation for instructions on installing both Archivematica and the Storage Service from Ansible or packages.

--- a/recovery.rst
+++ b/recovery.rst
@@ -25,6 +25,7 @@ recovery request administration page, click "Packages" then "View recovery
 requests" in the storage service administration web interface. Enter a reason
 for approval then click "Approve" to start recovery.
 
+.. _how-recovery-works:
 
 How Recovery Works
 ------------------
@@ -39,6 +40,7 @@ One an AIP recovery has been approved, the storage service does the following:
 #. Checks the fixity data of the stored AIP, failing recovery if the fixity
    check fails
 
+.. _example-recovery-command:
 
 Example Recovery command
 ------------------------
@@ -56,6 +58,8 @@ the notfication using a curl command. Here is an example:
 In this example, ``<description``, ``<int>`` and ``<email>`` are to be replaced
 by information for human use, to relay information from the person making the AIP
 recovery request to the Storage Service administrator.
+
+.. _reporting-recovery-progress:
 
 Reporting Recovery Progress to External Systems
 -----------------------------------------------


### PR DESCRIPTION
This change reformats the main page of the Storage Service documentation
to add headings for each of the main sections as well as links to
subsections, for easier navigation.

I've made some small changes on sub-pages so that I could add links to
subsections, but further updates will come in future PRs.