### PR TITLE
Correct the list of replicators

### DIFF
--- a/administrators.rst
+++ b/administrators.rst
@@ -927,17 +927,9 @@ Replicator locations can be configured to replicate the AIPs in one or more AIP
 storage locations. Replicators can be configured for each of the following
 protocols supported by the Storage Service:
 
+* Duracloud.
 * Local filesystem, including GPG encrypted.
 * S3.
-* Arkivum.
-* Duracloud.
-* DSpace via SWORD2 API.
-* DSpace via REST API.
-* Fedora via Sword2.
-* LOCKSS-o-matic.
-* NFS.
-* Pipeline local filesystem.
-* Swift.
 
 Replicators are associated with an AIP storage location via the storage
 location's configuration page. As such Replicators must be configured before


### PR DESCRIPTION
I wrote the list incorrectly based on the storage service prior to archivematica/Issues#1424 being fixed and so it included more replicators than the Storage Service actually has. Now 1424 is fixed we can see there are far fewer options here. Duracloud has been left in as it was recently added through 1350.

Connected to archivematica/Issues#1424
Connected to archivematica/Issues#1350
Connected to archivematica/Issues#685