### PR TITLE
Documentation for new Archipelago space option

### DIFF
--- a/administrators.rst
+++ b/administrators.rst
@@ -188,7 +188,7 @@ Archipelago
 **Configuring Archipelago as a storage service space:**
 Archipelago is currently supported for AIP Storage locations. Archipelago is built on the content manaagement system Drupal, which accepts JSON API calls to create new entities. 
 The storage service is able to send AIPs directly to Archipelago this way, 
-creating new entities as an 'AIP' content type.
+creating new entities as an 'AIP' content type. Curretly Archipelago integration is limited to storing AIP storage. Retrieving, re-ingesting, deleting and integrating the API of the storage service with Archivematica is not yet possible.
 
 **In Archipelago:**
 There are plans by Archipelago's developers to add AIP as a default object type for the platform. For now, we can create the AIP content type ourselves in a few steps.

--- a/administrators.rst
+++ b/administrators.rst
@@ -197,7 +197,7 @@ There are plans by Archipelago's developers to add AIP as a default object type 
 
 * Click Add content type. Name the content type AIP. 
 * Add a single strawberry field only to the content type, and this will complete setup to allow transfers from Archivematica. 
-* Ensure your user has write permissions via JSON API. 
+* Ensure your user has write permissions via JSON API. To do this, on Archipelago under Administration > Configuration > JSON:API, tick the box "Accept all JSON:API create, read, update, and delete operations." to allow JSON API writes to be made to archipelago. Specific permissions for the AIP content type can also be set under Administration > Struct > Content types > AIP > Manage permissions, where you can select if only authenticated users or anonymous users can create AIPs.
 
 For more info on creating the content type in Archipelago, see drupal instructions `here <https://www.drupal.org/docs/user_guide/en/structure-content-type.html>`_.
 

--- a/administrators.rst
+++ b/administrators.rst
@@ -181,6 +181,46 @@ more information.
 Access protocols
 ----------------
 
+.. _archipelago:
+
+Archipelago
+
+**Configuring Archipelago as a storage service space:**
+Archipelago is currently supported for AIP Storage locations. Archipelago is built on the content manaagement system Drupal, which accepts JSON API calls to create new entities. 
+The storage service is able to send AIPs directly to Archipelago this way, 
+creating new entities as an 'AIP' content type.
+
+**In Archipelago:**
+There are plans by Archipelago's developers to add AIP as a default object type for the platform. For now, we can create the AIP content type ourselves in a few steps.
+
+* In the Manage administrative menu, navigate to Structure > Content types (admin/structure/types). The Content types page appears showing all the available types of content. 
+
+* Click Add content type. Name the content type AIP. 
+* Add a single strawberry field only to the content type, and this will complete setup to allow transfers from Archivematica. 
+* Ensure your user has write permissions via JSON API. 
+
+For more info on creating the content type in Archipelago, see drupal instructions `here <https://www.drupal.org/docs/user_guide/en/structure-content-type.html>`_.
+
+
+**In Storage Service:**
+AIPs can be sent to an Archipelago instance via JSON API calls. The Archipelago instance URL is required, as well as an Archipelago username and password with write permissions on the platform. 
+* When creating the space, the staging path should be set to the default `/var/archievmatica/storage_service`. 
+* When creating the AIP storage location in the space, set the relative path to `/`. 
+
+During the transfer to Archipelago, the AIP file is uploaded first. If file uploads successfully, a new AIP type entity is created in Archipelago. 
+If the AIP file doesn't uploaded successfully, the new AIP entity is not created in Archipelago. The successful entity contains the uploaded file, and the corresponding Dublin Core metadata extracted from the mets.xml file associated with the AIP.
+
+Fields:
+
+* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+  for unlimited. This field is optional.
+* **Path**: the local path on the Storage Service machine to the CIFS share. This field is optional for Archipelago.
+* **Staging Path**: the absolute path to a staging area. When creating the space, the staging path should be set to the default `/var/archievmatica/storage_service`. 
+* **Archipealgo URL**: the hostname of the Archipelago web instance or IP address with port,
+  e.g. ``archipelago.example.com:8443``
+* **Archipelago username**: Archipelago username with write access required
+* **Archipelago password**: Arcihpelago password with write access required
+
 .. _arkivum:
 
 Arkivum

--- a/administrators.rst
+++ b/administrators.rst
@@ -188,7 +188,7 @@ Archipelago
 **Configuring Archipelago as a storage service space:**
 Archipelago is currently supported for AIP Storage locations. Archipelago is built on the content manaagement system Drupal, which accepts JSON API calls to create new entities. 
 The storage service is able to send AIPs directly to Archipelago this way, 
-creating new entities as an 'AIP' content type. Curretly Archipelago integration is limited to storing AIP storage. Retrieving, re-ingesting, deleting and integrating the API of the storage service with Archivematica is not yet possible.
+creating new entities as an 'AIP' content type. Currently Archipelago integration is limited to AIP storage only. Retrieving, re-ingesting, deleting AIPs and integrating the API of the storage service with Archivematica is not yet implemented.
 
 **In Archipelago:**
 There are plans by Archipelago's developers to add AIP as a default object type for the platform. For now, we can create the AIP content type ourselves in a few steps.

--- a/administrators.rst
+++ b/administrators.rst
@@ -204,7 +204,7 @@ For more info on creating the content type in Archipelago, see drupal instructio
 
 **In Storage Service:**
 AIPs can be sent to an Archipelago instance via JSON API calls. The Archipelago instance URL is required, as well as an Archipelago username and password with write permissions on the platform. 
-* When creating the space, the staging path should be set to the default `/var/archievmatica/storage_service`. 
+* When creating the space, the staging path should be set to the default `/var/archivematica/storage_service`. 
 * When creating the AIP storage location in the space, set the relative path to `/`. 
 
 During the transfer to Archipelago, the AIP file is uploaded first. If file uploads successfully, a new AIP type entity is created in Archipelago. 
@@ -215,11 +215,11 @@ Fields:
 * **Size**: the maximum size allowed for this space. Set to 0 or leave blank
   for unlimited. This field is optional.
 * **Path**: the local path on the Storage Service machine to the CIFS share. This field is optional for Archipelago.
-* **Staging Path**: the absolute path to a staging area. When creating the space, the staging path should be set to the default `/var/archievmatica/storage_service`. 
+* **Staging Path**: the absolute path to a staging area. When creating the space, the staging path should be set to the default `/var/archivematica/storage_service`. 
 * **Archipealgo URL**: the hostname of the Archipelago web instance or IP address with port,
   e.g. ``archipelago.example.com:8443``
 * **Archipelago username**: Archipelago username with write access required
-* **Archipelago password**: Arcihpelago password with write access required
+* **Archipelago password**: Archipelago password with write access required
 
 .. _arkivum:
 


### PR DESCRIPTION
Added documentation for configuring new space option, Archipelago. Describes setup on Archipelago side and follows format of describing existing Fields as the other space documentation.