### PR TITLE
Update size & quota fields

### DIFF
--- a/administrators.rst
+++ b/administrators.rst
@@ -208,7 +208,7 @@ Storage Service.
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the local path on the Storage Service machine to the CIFS share,
   e.g. ``/mnt/astor``
@@ -231,7 +231,7 @@ Storage Service v0.13 (and higher).
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
@@ -350,7 +350,7 @@ custom properties which can be defined:
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank for
+* **Size**: the maximum size allowed for this space. Leave blank for
   unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
@@ -435,7 +435,7 @@ Fields:
 
 .. _restrictedmetadata:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
@@ -468,7 +468,7 @@ is in beta testing as of Storage Service 0.9/Archivematica 1.5/Islandora
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
@@ -508,7 +508,7 @@ a GPG key on the :ref:`Administration page <administration>`.
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
@@ -537,7 +537,7 @@ mounted, we recommend using a more specific Space if one is available.
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
@@ -555,7 +555,7 @@ Network (PLN).
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
@@ -585,7 +585,7 @@ Archivematica pipeline.
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to where the space is mounted on the filesystem
   local to the Storage Service.
@@ -622,7 +622,7 @@ Local Filesystem.
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to where the space is mounted on the filesystem
   local to the Storage Service.
@@ -674,7 +674,7 @@ higher.
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
@@ -710,7 +710,7 @@ Transfer Source :ref:`locations <location-purposes>`.
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: *Not required: see below*.
 * **Staging path**: the absolute path to a staging area on the same server as
@@ -947,7 +947,7 @@ Replicator locations can be created in a Write-Only Replica Staging space.
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Size**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
@@ -997,7 +997,7 @@ Fields:
 * **Relative Path**: the path to this location, relative to the space that
   contains it.
 * **Description**: a description of the location to be displayed to the user.
-* **Quota**: the maximum size allowed for this space. Set to 0 or leave blank
+* **Quota**: the maximum size allowed for this space. Leave blank
   for unlimited. This field is optional.
 * **Enabled**: if checked, this location will be accessible to pipelines
   associated with it. If unchecked, it will not be available to any pipeline.

--- a/administrators.rst
+++ b/administrators.rst
@@ -297,7 +297,8 @@ DuraCloud with Archivematica <archivematica:duracloud-setup>`.
 Fields:
 
 * **Access protocol**: DuraCloud
-* **Size**: *This field is optional.*
+* **Size**: the maximum size allowed for this space. Leave blank
+  for unlimited. This field is optional.
 * **Path**: Leave this field blank.
 * **Staging path**: A location on your local disk where Archivematica can
   place files for staging purposes, for example
@@ -350,8 +351,8 @@ custom properties which can be defined:
 
 Fields:
 
-* **Size**: the maximum size allowed for this space. Leave blank for
-  unlimited. This field is optional.
+* **Size**: the maximum size allowed for this space. Leave blank
+  for unlimited. This field is optional.
 * **Path**: the absolute path to the Space on the local filesystem.
 * **Staging path**: the absolute path to a staging area. Must be UNIX filesystem
   compatible and preferably will be located on the same filesystem as the path.
@@ -654,7 +655,8 @@ file or via environment variables (the recommended method). See the
 Fields:
 
 * **Access protocol**: RClone
-* **Size**: *This field is optional.*
+* **Size**: the maximum size allowed for this space. Leave blank
+  for unlimited. This field is optional.
 * **Path**: Leave this field blank.
 * **Staging path**: A location on your local disk where Archivematica can
   place files for staging purposes, for example


### PR DESCRIPTION
Space size 0 refers to an integer value which results in error [StorageException](https://github.com/artefactual/archivematica-storage-service/blob/7d62d76e2a84cbf07b37229f0f70e8f6300477f3/storage_service/locations/models/package.py#L444-L479). By keeping it blank would set unlimited.

Connected to : https://github.com/archivematica/Issues/issues/1489